### PR TITLE
Use cryptography to load PKCS12 certificates

### DIFF
--- a/octavia/tests/unit/certificates/manager/test_barbican.py
+++ b/octavia/tests/unit/certificates/manager/test_barbican.py
@@ -15,7 +15,6 @@ from unittest import mock
 import uuid
 
 from barbicanclient.v1 import secrets
-from OpenSSL import crypto
 
 import octavia.certificates.common.barbican as barbican_common
 import octavia.certificates.common.cert as cert
@@ -138,10 +137,11 @@ class TestBarbicanManager(base.TestCase):
                          sorted(data.get_intermediates()))
         self.assertIsNone(data.get_private_key_passphrase())
 
-    @mock.patch('OpenSSL.crypto.load_pkcs12')
+    @mock.patch('cryptography.hazmat.primitives.serialization.pkcs12.'
+                'load_pkcs12')
     def test_get_cert_bad_pkcs12(self, mock_load_pkcs12):
 
-        mock_load_pkcs12.side_effect = [crypto.Error]
+        mock_load_pkcs12.side_effect = [ValueError]
 
         # Mock out the client
         self.bc.secrets.get.return_value = self.secret_pkcs12

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,6 @@ python-barbicanclient>=4.5.2 # Apache-2.0
 python-glanceclient>=2.8.0 # Apache-2.0
 python-novaclient>=9.1.0 # Apache-2.0
 python-cinderclient>=3.3.0 # Apache-2.0
-pyOpenSSL>=19.1.0 # Apache-2.0
 WSME>=0.8.0 # MIT
 Jinja2>=2.10 # BSD License (3 clause)
 taskflow>=4.4.0 # Apache-2.0


### PR DESCRIPTION
... because implementation in PyOpenSSL has been derprecated, according to the following warning.

```
DeprecationWarning: PKCS#12 support in pyOpenSSL is deprecated. You
should use the APIs in cryptography.
```

Closes-Bug: #2042787
Change-Id: Ic81e98c54c4bce100e3f44ff1a2fe6ce7b7f4256
(cherry picked from commit d1d7fe7197dab64592f745424c469ddac0175b2d)